### PR TITLE
Use the GITHUB_SERVER_URL variable to determine the remote

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ if [ "${name}" = "null" ]; then
   name=$(yq -r .name config/final.yml)
 fi
 
-remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+remote_repo="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@${GITHUB_SERVER_URL#https://}/${GITHUB_REPOSITORY}.git"
 
 # configure git
 git config --global user.name "actions/bosh-releaser@v1"


### PR DESCRIPTION
GITHUB_SERVER_URL contains the host that github is running on (including `https://`), we can use this to determine the remote location when pushing to a github enterprise server.